### PR TITLE
Bump rack version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     et-orbi (1.0.9)
       tzinfo
     mustermann (1.0.2)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-protection (2.0.3)
       rack
     redis (4.0.1)


### PR DESCRIPTION


@honestbee/devops  Github has reported a security vulnerability in Rack.
```

honestbee / sidekiq-monitorKnown security vulnerabilities detectedDependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | honestbee / sidekiq-monitorKnown security vulnerabilities detectedDependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | honestbee / sidekiq-monitorKnown security vulnerabilities detectedDependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | honestbee / sidekiq-monitorKnown security vulnerabilities detectedDependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | Dependencyrack | Version>= 2.0.4 < 2.0.6 | Upgrade to~> 2.0.6 | VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severity | CVE-2018-16470 Moderate severity | CVE-2018-16471 Moderate severity | Defined inGemfile.lock
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
honestbee / sidekiq-monitorKnown security vulnerabilities detectedDependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | honestbee / sidekiq-monitorKnown security vulnerabilities detectedDependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | honestbee / sidekiq-monitorKnown security vulnerabilities detectedDependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | Dependencyrack | Version>= 2.0.4 < 2.0.6 | Upgrade to~> 2.0.6 | VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severity | CVE-2018-16470 Moderate severity | CVE-2018-16471 Moderate severity | Defined inGemfile.lock
honestbee / sidekiq-monitorKnown security vulnerabilities detectedDependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | honestbee / sidekiq-monitorKnown security vulnerabilities detectedDependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | Dependencyrack | Version>= 2.0.4 < 2.0.6 | Upgrade to~> 2.0.6 | VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severity | CVE-2018-16470 Moderate severity | CVE-2018-16471 Moderate severity | Defined inGemfile.lock
honestbee / sidekiq-monitorKnown security vulnerabilities detectedDependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | Dependencyrack | Version>= 2.0.4 < 2.0.6 | Upgrade to~> 2.0.6 | VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severity | CVE-2018-16470 Moderate severity | CVE-2018-16471 Moderate severity | Defined inGemfile.lock

DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | Dependencyrack | Version>= 2.0.4 < 2.0.6 | Upgrade to~> 2.0.6 | VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severity | CVE-2018-16470 Moderate severity | CVE-2018-16471 Moderate severity | Defined inGemfile.lock
DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | Dependencyrack | Version>= 2.0.4 < 2.0.6 | Upgrade to~> 2.0.6 | VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severity | CVE-2018-16470 Moderate severity | CVE-2018-16471 Moderate severity | Defined inGemfile.lock
DependencyrackVersion>= 2.0.4 < 2.0.6Upgrade to~> 2.0.6VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severityDefined inGemfile.lock | Dependencyrack | Version>= 2.0.4 < 2.0.6 | Upgrade to~> 2.0.6 | VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severity | CVE-2018-16470 Moderate severity | CVE-2018-16471 Moderate severity | Defined inGemfile.lock
Dependencyrack | Version>= 2.0.4 < 2.0.6 | Upgrade to~> 2.0.6
VulnerabilitiesCVE-2018-16470 Moderate severityCVE-2018-16471 Moderate severity | CVE-2018-16470 Moderate severity | CVE-2018-16471 Moderate severity | Defined inGemfile.lock
CVE-2018-16470 Moderate severity
CVE-2018-16471 Moderate severity


```